### PR TITLE
Fe dev kx15

### DIFF
--- a/code/client/src/App.tsx
+++ b/code/client/src/App.tsx
@@ -1,11 +1,5 @@
 import { Button, Col, Container, Dropdown, Row } from "react-bootstrap";
-import {
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom";
+import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import NavBar from "./components/NavBar";
 import LeftSideBar from "./components/LeftSideBar";
@@ -41,12 +35,9 @@ function App() {
   const location = useLocation();
   const [isViewLinkedDocuments, setIsViewLinkedDocuments] = useState(false);
   const [filteredDocuments, setFilteredDocuments] = useState<Document[]>([]);
-  const [currentLayer, setCurrentLayer] =
-    useState<keyof typeof tileLayers>("satellite"); // Stato per il layer selezionato
+  const [currentLayer, setCurrentLayer] = useState<keyof typeof tileLayers>("satellite"); // Stato per il layer selezionato
 
-  const [uploadDocumentId, setUploadDocumentId] = useState<number | undefined>(
-    undefined
-  );
+  const [uploadDocumentId, setUploadDocumentId] = useState<number | undefined>(undefined);
 
   const [newDocument, setNewDocument] = useState<NewDocument>({
     title: "",
@@ -161,11 +152,7 @@ function App() {
         <Container>
           <SidebarProvider>
             <UserContext.Provider value={user}>
-              <NavBar
-                setSearchTitle={setSearchTitle}
-                loggedIn={loggedIn}
-                doLogOut={doLogOut}
-              />
+              <NavBar setSearchTitle={setSearchTitle} loggedIn={loggedIn} doLogOut={doLogOut} />
               {location.pathname !== "/home" && location.pathname !== "/" && (
                 <LeftSideBar logout={doLogOut} />
               )}
@@ -187,15 +174,19 @@ function App() {
                 {/* no login required */}
                 <Route
                   path="/home"
+                  element={<HomePage loggedIn={loggedIn} username={user?.username} />}
+                />
+                <Route
+                  path="/diagram"
                   element={
-                    <HomePage loggedIn={loggedIn} username={user?.username} />
+                    <DiagramWrapper
+                      searchTitle={searchTitle}
+                      filteredDocuments={filteredDocuments}
+                      setFilteredDocuments={setFilteredDocuments}
+                    />
                   }
                 />
-                <Route path="/diagram" element={<DiagramWrapper />} />
-                <Route
-                  path="/documents/:documentId"
-                  element={<DocumentDetails />}
-                />
+                <Route path="/documents/:documentId" element={<DocumentDetails />} />
                 <Route
                   path="/explore-map"
                   element={
@@ -213,18 +204,13 @@ function App() {
                 {/* urban-planner login required */}
                 <Route
                   path="/urban-planner"
-                  element={
-                    loggedIn ? <UrbanPlanner /> : <Navigate to="/login" />
-                  }
+                  element={loggedIn ? <UrbanPlanner /> : <Navigate to="/login" />}
                 />
                 <Route
                   path="/urban-planner/add-document"
                   element={
                     loggedIn ? (
-                      <AddDocumentForm
-                        document={newDocument}
-                        setDocument={setNewDocument}
-                      />
+                      <AddDocumentForm document={newDocument} setDocument={setNewDocument} />
                     ) : (
                       <Navigate to="/login" />
                     )
@@ -232,9 +218,7 @@ function App() {
                 />
                 <Route
                   path="/urban-planner/link-documents"
-                  element={
-                    loggedIn ? <LinkDocumentForm /> : <Navigate to="/login" />
-                  }
+                  element={loggedIn ? <LinkDocumentForm /> : <Navigate to="/login" />}
                 />
                 <Route
                   path="/urban-planner/documents-list"
@@ -267,10 +251,7 @@ function App() {
       <Col>
         {loggedIn && location.pathname == "/explore-map" ? (
           <Row>
-            <Button
-              onClick={() => navigate("/urban-planner/add-document")}
-              className="add-button"
-            >
+            <Button onClick={() => navigate("/urban-planner/add-document")} className="add-button">
               <FaPlus color="white" size={25} />
             </Button>
           </Row>
@@ -278,11 +259,7 @@ function App() {
         {isViewLinkedDocuments && location.pathname == "/explore-map" ? (
           <Row>
             <Button onClick={handleSetDocuments} className="view-all-button">
-              <img
-                src={ViewAll}
-                alt="ViewAll"
-                style={{ width: "30px", height: "30px" }}
-              />
+              <img src={ViewAll} alt="ViewAll" style={{ width: "30px", height: "30px" }} />
             </Button>
           </Row>
         ) : null}
@@ -295,9 +272,7 @@ function App() {
                   {Object.keys(tileLayers).map((layer) => (
                     <Dropdown.Item
                       key={layer}
-                      onClick={() =>
-                        setCurrentLayer(layer as keyof typeof tileLayers)
-                      }
+                      onClick={() => setCurrentLayer(layer as keyof typeof tileLayers)}
                     >
                       <img
                         src={layerIcons[layer]}

--- a/code/client/src/App.tsx
+++ b/code/client/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
   const [isViewLinkedDocuments, setIsViewLinkedDocuments] = useState(false);
   const [filteredDocuments, setFilteredDocuments] = useState<Document[]>([]);
   const [currentLayer, setCurrentLayer] = useState<keyof typeof tileLayers>("satellite"); // Stato per il layer selezionato
-
+  const [filterTableVisible, setFilterTableVisible] = useState(false);
   const [uploadDocumentId, setUploadDocumentId] = useState<number | undefined>(undefined);
 
   const [newDocument, setNewDocument] = useState<NewDocument>({
@@ -152,7 +152,15 @@ function App() {
         <Container>
           <SidebarProvider>
             <UserContext.Provider value={user}>
-              <NavBar setSearchTitle={setSearchTitle} loggedIn={loggedIn} doLogOut={doLogOut} />
+              <NavBar
+                setSearchTitle={setSearchTitle}
+                loggedIn={loggedIn}
+                doLogOut={doLogOut}
+                filterTableVisible={filterTableVisible}
+                setFilterTableVisible={setFilterTableVisible}
+                filteredDocuments={filteredDocuments}
+                setFilteredDocuments={setFilteredDocuments}
+              />
               {location.pathname !== "/home" && location.pathname !== "/" && (
                 <LeftSideBar logout={doLogOut} />
               )}
@@ -183,6 +191,8 @@ function App() {
                       searchTitle={searchTitle}
                       filteredDocuments={filteredDocuments}
                       setFilteredDocuments={setFilteredDocuments}
+                      filterTableVisible={filterTableVisible}
+                      setFilterTableVisible={setFilterTableVisible}
                     />
                   }
                 />

--- a/code/client/src/components/NavBar.tsx
+++ b/code/client/src/components/NavBar.tsx
@@ -28,7 +28,9 @@ const NavBar: FC<NavBarProps> = (props) => {
   };
 
   const showSearchBar =
-    location.pathname === "/urban-planner/documents-list" || location.pathname === "/explore-map";
+    location.pathname === "/urban-planner/documents-list" ||
+    location.pathname === "/explore-map" ||
+    location.pathname === "/diagram";
 
   const loggedIn = props.loggedIn;
 

--- a/code/client/src/components/NavBar.tsx
+++ b/code/client/src/components/NavBar.tsx
@@ -5,11 +5,17 @@ import Logo from "../assets/icons/logo.svg";
 import { Dispatch, FC, SetStateAction } from "react";
 import { LogInIcon } from "lucide-react";
 import { LogOutIcon } from "lucide-react";
+import Document from "../models/document";
+import { Undo2Icon } from "lucide-react";
 
 interface NavBarProps {
   setSearchTitle: Dispatch<SetStateAction<string>>;
   loggedIn: Boolean;
   doLogOut: () => void;
+  filterTableVisible: boolean;
+  setFilterTableVisible: Dispatch<SetStateAction<boolean>>;
+  filteredDocuments: Document[];
+  setFilteredDocuments: Dispatch<SetStateAction<Document[]>>;
 }
 
 const NavBar: FC<NavBarProps> = (props) => {
@@ -26,6 +32,13 @@ const NavBar: FC<NavBarProps> = (props) => {
     (document.getElementById("input") as HTMLInputElement).value = "";
     props.setSearchTitle("");
   };
+
+  const handleResetNodes = () => {
+    props.setFilteredDocuments([]);
+    props.setFilterTableVisible(false);
+  };
+
+  console.log(props.filteredDocuments);
 
   const showSearchBar =
     location.pathname === "/urban-planner/documents-list" ||
@@ -100,6 +113,23 @@ const NavBar: FC<NavBarProps> = (props) => {
               Search
             </button>
           </Col>
+          {location.pathname === "/diagram" && (
+            <Col>
+              <button
+                className="filter-button-diagram"
+                onClick={() => props.setFilterTableVisible(!props.filterTableVisible)}
+              >
+                Filter
+              </button>
+            </Col>
+          )}
+          {location.pathname === "/diagram" && props.filteredDocuments.length > 0 && (
+            <Col>
+              <button className="undo-filter-button-diagram" onClick={handleResetNodes}>
+                <Undo2Icon size={24} color="#3d52a0" />
+              </button>
+            </Col>
+          )}
         </Row>
       )}
       {!loggedIn && (

--- a/code/client/src/components/NavBar.tsx
+++ b/code/client/src/components/NavBar.tsx
@@ -2,11 +2,12 @@ import { Button, Col, OverlayTrigger, Row, Tooltip } from "react-bootstrap";
 import { useLocation, useNavigate } from "react-router-dom";
 import "../index.css";
 import Logo from "../assets/icons/logo.svg";
-import { Dispatch, FC, SetStateAction } from "react";
+import { Dispatch, FC, SetStateAction, useEffect, useState } from "react";
 import { LogInIcon } from "lucide-react";
 import { LogOutIcon } from "lucide-react";
 import Document from "../models/document";
 import { Undo2Icon } from "lucide-react";
+import API from "../API/API";
 
 interface NavBarProps {
   setSearchTitle: Dispatch<SetStateAction<string>>;
@@ -22,6 +23,15 @@ const NavBar: FC<NavBarProps> = (props) => {
   const location = useLocation();
   const isLoginPage = location.pathname === "/login";
   const navigate = useNavigate();
+  const [allDocs, setAllDocs] = useState<Document[]>([]);
+
+  useEffect(() => {
+    async function setInitialDocs() {
+      const allDocs = await API.getDocuments();
+      setAllDocs(allDocs);
+    }
+    setInitialDocs();
+  }, []);
 
   const handleChange = () => {
     var value = (document.getElementById("input") as HTMLInputElement).value;
@@ -33,12 +43,10 @@ const NavBar: FC<NavBarProps> = (props) => {
     props.setSearchTitle("");
   };
 
-  const handleResetNodes = () => {
-    props.setFilteredDocuments([]);
+  const handleResetNodes = async () => {
+    props.setFilteredDocuments(allDocs);
     props.setFilterTableVisible(false);
   };
-
-  console.log(props.filteredDocuments);
 
   const showSearchBar =
     location.pathname === "/urban-planner/documents-list" ||
@@ -123,7 +131,7 @@ const NavBar: FC<NavBarProps> = (props) => {
               </button>
             </Col>
           )}
-          {location.pathname === "/diagram" && props.filteredDocuments.length > 0 && (
+          {location.pathname === "/diagram" && props.filteredDocuments.length < allDocs.length && (
             <Col>
               <button className="undo-filter-button-diagram" onClick={handleResetNodes}>
                 <Undo2Icon size={24} color="#3d52a0" />

--- a/code/client/src/index.css
+++ b/code/client/src/index.css
@@ -456,7 +456,8 @@ input {
   color: #4a69b3; /* Colore dell'icona di cancellazione */
 }
 
-.search-button {
+.search-button,
+.filter-button-diagram {
   background-color: #3d52a0;
   color: white;
   padding: 0.5rem 1rem;
@@ -467,8 +468,14 @@ input {
   height: 38px;
 }
 
-.search-button:hover {
+.search-button:hover,
+.filter-button-diagram:hover {
   background-color: #3d52a0;
+}
+
+.undo-filter-button-diagram {
+  background-color: transparent;
+  border: none;
 }
 
 /*

--- a/code/client/src/modules/GeneralPages/Diagram/Diagram.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/Diagram.tsx
@@ -80,6 +80,10 @@ const Diagram = (props: any) => {
     navigate(`/documents/${nodeId}`);
   };
 
+  const handleResetNodes = () => {
+    setNodes(initialNodes);
+  };
+
   // Update nodes based on filtered documents
   useEffect(() => {
     if (filteredDocuments.length > 0) {
@@ -120,12 +124,14 @@ const Diagram = (props: any) => {
             className="open-filter-table-button"
             onClick={() => setFilterTableVisible(!filterTableVisible)}
           >
-            Filter <img src={FilterIcon} alt="filter" />
+            Filter
+            {/* <img src={FilterIcon} alt="filter" /> */}
           </button>
         </Col>
         <Col>
-          <button className="reset-filter-table-button" onClick={() => setNodes(initialNodes)}>
-            Reset <img src={Close} alt="close" />
+          <button className="reset-filter-table-button" onClick={handleResetNodes}>
+            Reset
+            {/* <img src={Close} alt="close" /> */}
           </button>
         </Col>
       </Row>
@@ -134,6 +140,7 @@ const Diagram = (props: any) => {
           <FilterTable
             setFilteredDocuments={setFilteredDocuments}
             setFilterTableVisible={setFilterTableVisible}
+            handleResetNodes={handleResetNodes}
           />
         </div>
       )}

--- a/code/client/src/modules/GeneralPages/Diagram/Diagram.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/Diagram.tsx
@@ -19,6 +19,8 @@ import Document from "../../../models/document";
 import { Col, Row } from "react-bootstrap";
 
 interface DiagramProps {
+  filterTableVisible: boolean;
+  setFilterTableVisible: React.Dispatch<React.SetStateAction<boolean>>;
   filteredDocuments: Document[];
   setFilteredDocuments: React.Dispatch<React.SetStateAction<Document[]>>;
   searchTitle: string;
@@ -32,6 +34,8 @@ interface DiagramProps {
 }
 
 const Diagram = (props: DiagramProps) => {
+  const filterTableVisible = props.filterTableVisible;
+  const setFilterTableVisible = props.setFilterTableVisible;
   const filteredDocuments = props.filteredDocuments;
   const setFilteredDocuments = props.setFilteredDocuments;
   const searchTitle = props.searchTitle;
@@ -50,7 +54,6 @@ const Diagram = (props: DiagramProps) => {
     { visible: false, title: "", x: 0, y: 0 }
   );
   const { isSidebarOpen } = useSidebar();
-  const [filterTableVisible, setFilterTableVisible] = useState(false);
 
   const onNodesChange = useCallback(
     (changes: any) => setNodes((nds: any) => applyNodeChanges(changes, nds)),
@@ -94,14 +97,19 @@ const Diagram = (props: DiagramProps) => {
   };
 
   const handleResetNodes = () => {
-    setNodes(initialNodes);
+    setFilteredDocuments([]);
+    setFilterTableVisible(false);
   };
 
   // Update nodes based on filtered documents
   useEffect(() => {
-    const filteredNodeIds = filteredDocuments.map((doc) => doc.documentId);
-    const updatedNodes = nodes.filter((node: Node) => filteredNodeIds.includes(Number(node.id)));
-    setNodes(updatedNodes);
+    if (filteredDocuments.length > 0) {
+      const filteredNodeIds = filteredDocuments.map((doc) => doc.documentId);
+      const updatedNodes = nodes.filter((node: Node) => filteredNodeIds.includes(Number(node.id)));
+      setNodes(updatedNodes);
+    } else {
+      setNodes(initialNodes);
+    }
   }, [filteredDocuments]);
 
   // update documents list based on searchTitle
@@ -139,23 +147,6 @@ const Diagram = (props: DiagramProps) => {
           {tooltip.title}
         </div>
       )}
-      <Row>
-        <Col>
-          <button
-            className="open-filter-table-button"
-            onClick={() => setFilterTableVisible(!filterTableVisible)}
-          >
-            Filter
-            {/* <img src={FilterIcon} alt="filter" /> */}
-          </button>
-        </Col>
-        <Col>
-          <button className="reset-filter-table-button" onClick={handleResetNodes}>
-            Reset
-            {/* <img src={Close} alt="close" /> */}
-          </button>
-        </Col>
-      </Row>
       {filterTableVisible && (
         <div className="popup-diagram">
           <FilterTable

--- a/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
@@ -17,6 +17,8 @@ interface DiagramWrapperProps {
   searchTitle: string;
   filteredDocuments: Document[];
   setFilteredDocuments: React.Dispatch<React.SetStateAction<Document[]>>;
+  filterTableVisible: boolean;
+  setFilterTableVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const DiagramWrapper = (props: DiagramWrapperProps) => {
@@ -123,6 +125,8 @@ const DiagramWrapper = (props: DiagramWrapperProps) => {
 
   return (
     <Diagram
+      filterTableVisible={props.filterTableVisible}
+      setFilterTableVisible={props.setFilterTableVisible}
       filteredDocuments={props.filteredDocuments}
       setFilteredDocuments={props.setFilteredDocuments}
       searchTitle={props.searchTitle}

--- a/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
@@ -15,10 +15,13 @@ import Diagram from "./Diagram";
 
 const DiagramWrapper = () => {
   const [nodes, setNodes] = useState<Node[]>([]);
+  const [initialNodes, setInitialNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
 
   const [yearWidths, setYearWidths] = useState<number[]>([]);
   const [scrollWidth, setScrollWidth] = useState<number>(1);
+
+  const [filteredDocuments, setFilteredDocuments] = useState<Document[]>([]);
 
   const { getAvailablePosition } = useOccupiedPositions();
 
@@ -71,6 +74,7 @@ const DiagramWrapper = () => {
         else setScrollWidth(document.documentElement.clientWidth - 75);
 
         setNodes(newNodes);
+        setInitialNodes(newNodes);
       }
       if (initialConnections.length) {
         const connectionsMap: Record<string, string[]> = {};
@@ -115,6 +119,7 @@ const DiagramWrapper = () => {
 
   return (
     <Diagram
+      initialNodes={initialNodes}
       setNodes={setNodes}
       setEdges={setEdges}
       scrollWidth={scrollWidth}

--- a/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
@@ -34,6 +34,7 @@ const DiagramWrapper = (props: DiagramWrapperProps) => {
   useEffect(() => {
     async function getDocs() {
       const initialDocs: Document[] = await API.getDocuments();
+      props.setFilteredDocuments(initialDocs);
       const initialConnections: Connection[] = await API.getConnections();
       if (initialDocs.length) {
         let newNodes: Node[] = [];

--- a/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
+++ b/code/client/src/modules/GeneralPages/Diagram/DiagramWrapper.tsx
@@ -13,15 +13,19 @@ import {
 import { useOccupiedPositions } from "../../../components/diagramComponents/utils/positionUtils";
 import Diagram from "./Diagram";
 
-const DiagramWrapper = () => {
+interface DiagramWrapperProps {
+  searchTitle: string;
+  filteredDocuments: Document[];
+  setFilteredDocuments: React.Dispatch<React.SetStateAction<Document[]>>;
+}
+
+const DiagramWrapper = (props: DiagramWrapperProps) => {
   const [nodes, setNodes] = useState<Node[]>([]);
   const [initialNodes, setInitialNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
 
   const [yearWidths, setYearWidths] = useState<number[]>([]);
   const [scrollWidth, setScrollWidth] = useState<number>(1);
-
-  const [filteredDocuments, setFilteredDocuments] = useState<Document[]>([]);
 
   const { getAvailablePosition } = useOccupiedPositions();
 
@@ -119,6 +123,9 @@ const DiagramWrapper = () => {
 
   return (
     <Diagram
+      filteredDocuments={props.filteredDocuments}
+      setFilteredDocuments={props.setFilteredDocuments}
+      searchTitle={props.searchTitle}
       initialNodes={initialNodes}
       setNodes={setNodes}
       setEdges={setEdges}

--- a/code/client/src/modules/GeneralPages/Map/DraggableMarker.tsx
+++ b/code/client/src/modules/GeneralPages/Map/DraggableMarker.tsx
@@ -62,16 +62,12 @@ const DraggableMarker = ({
   );
 
   useEffect(() => {
-    API.getDocumentById(document.documentId).then((doc) =>
-      setDocumentSelected(doc)
-    );
+    API.getDocumentById(document.documentId).then((doc) => setDocumentSelected(doc));
   }, [isViewLinkedDocuments]);
 
   useEffect(() => {
     API.getGeoreferences().then((georeferences) => {
-      const georef = georeferences.find(
-        (g) => g.georeferenceId === document.georeferenceId
-      );
+      const georef = georeferences.find((g) => g.georeferenceId === document.georeferenceId);
       setGeoreference(georef);
     });
   }, [documentSelected]);
@@ -85,19 +81,14 @@ const DraggableMarker = ({
       setAllDocuments(allDocs);
 
       // Filter linked documents from allDocs
-      const linkedDocuments = documentSelected.linkedDocuments.map(
-        (linkedDoc) => {
-          return allDocuments.find(
-            (doc) => doc.documentId === linkedDoc.documentId
-          );
-        }
-      );
+      const linkedDocuments = documentSelected.linkedDocuments.map((linkedDoc) => {
+        return allDocuments.find((doc) => doc.documentId === linkedDoc.documentId);
+      });
 
       // Filter unique documents by documentId
       const uniqueDocuments = linkedDocuments.filter(
         (doc, index, self) =>
-          doc &&
-          index === self.findIndex((d) => d?.documentId === doc.documentId)
+          doc && index === self.findIndex((d) => d?.documentId === doc.documentId)
       );
 
       // Update state with linked documents
@@ -134,9 +125,7 @@ const DraggableMarker = ({
       newCoordinates[1] >= 18.3 &&
       newCoordinates[1] <= 22.6
     ) {
-      API.updateDocumentGeoreference(document.documentId, [
-        newCoordinates,
-      ]).then((response) => {
+      API.updateDocumentGeoreference(document.documentId, [newCoordinates]).then((response) => {
         const { message } = response;
         setDocuments((prevDocuments) =>
           prevDocuments.map((doc) =>
@@ -151,11 +140,7 @@ const DraggableMarker = ({
         showToast("Success!", "Georeference updated successfully", false);
       });
     } else {
-      showToast(
-        "Cannot update coordinates",
-        "Please choose coordinates within Kiruna area",
-        true
-      );
+      showToast("Cannot update coordinates", "Please choose coordinates within Kiruna area", true);
     }
   };
 
@@ -252,36 +237,38 @@ const DraggableMarker = ({
         }}
         position={position}
         ref={markerRef}
-        icon={
-          document.nodeType
-            ? getCustomIcon(document.nodeType, isSelected)
-            : customIcon
-        }
+        icon={document.nodeType ? getCustomIcon(document.nodeType, isSelected) : customIcon}
       >
-        <Tooltip
-          direction="top"
-          offset={[0, -30]}
-          opacity={1}
-          permanent={false}
-        >
+        <Tooltip direction="top" offset={[0, -30]} opacity={1} permanent={false}>
           {document.title}
         </Tooltip>
         <Popup autoClose={false} closeButton={true}>
           <div>
-            <h5>{document.title}</h5>
+            <h5>
+              <span
+                className="clickable-title"
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/documents/${document.documentId}`)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ")
+                    navigate(`/documents/${document.documentId}`);
+                }}
+                style={{
+                  cursor: "pointer",
+                }}
+              >
+                {document.title}
+              </span>
+            </h5>
             <p>Description: {document.description}</p>
             <p>Scale: {document.scale}</p>
             <p>Type: {document.nodeType}</p>
             <p>Issuance Date: {document.issuanceDate}</p>
-            {georeference?.isArea === 1 && (
-              <p>Area name: {georeference.georeferenceName}</p>
-            )}
+            {georeference?.isArea === 1 && <p>Area name: {georeference.georeferenceName}</p>}
             <Row>
               <Col>
-                <Button
-                  className="view-linked-documents-button"
-                  onClick={handleViewConnections}
-                >
+                <Button className="view-linked-documents-button" onClick={handleViewConnections}>
                   <img
                     className="view-linked-documents-icon"
                     src={ViewConnections}
@@ -291,21 +278,8 @@ const DraggableMarker = ({
                 <p>View Connections</p>
               </Col>
               <Row>
-                <button
-                  className="draggable-toggle-btn"
-                  onClick={() =>
-                    handleDocumentClick(document.documentId.toString())
-                  }
-                >
-                  Document detail
-                </button>
-              </Row>
-              <Row>
                 {user && (
-                  <button
-                    className="draggable-toggle-btn"
-                    onClick={toggleDraggable}
-                  >
+                  <button className="draggable-toggle-btn" onClick={toggleDraggable}>
                     {draggable ? "Stop Moving" : "Update georeference"}
                   </button>
                 )}

--- a/code/client/src/modules/GeneralPages/Map/DraggableMarker.tsx
+++ b/code/client/src/modules/GeneralPages/Map/DraggableMarker.tsx
@@ -205,8 +205,9 @@ const DraggableMarker = ({
           positions={polygonCoords}
           pathOptions={{
             color: "#3d52a0",
-            weight: 3,
+            weight: 5,
             opacity: 1,
+            dashArray: "5, 10",
             fillColor: "transparent",
             fillOpacity: 0,
           }}

--- a/code/client/src/modules/GeneralPages/Map/ExploreMap.tsx
+++ b/code/client/src/modules/GeneralPages/Map/ExploreMap.tsx
@@ -65,12 +65,7 @@ const ExploreMap = ({
       setList(
         geo.reduce((acc: Georeference[], current: Georeference) => {
           const coord = JSON.parse(current.coordinates);
-          if (
-            !acc.some(
-              (area) =>
-                JSON.stringify(area.coordinates) === JSON.stringify(coord)
-            )
-          ) {
+          if (!acc.some((area) => JSON.stringify(area.coordinates) === JSON.stringify(coord))) {
             acc.push(current);
           }
           return acc;
@@ -158,11 +153,11 @@ const ExploreMap = ({
                 key={`${index}-${area.georeferenceId}`}
                 positions={coords}
                 pathOptions={{
-                  color: "#3d52a0",
-                  weight: 3,
-                  opacity: 0.7,
-                  fillColor: "#3d52a0",
-                  fillOpacity: 0.3,
+                  color: area.areaColor,
+                  weight: 5,
+                  opacity: 0.8,
+                  dashArray: "5, 10",
+                  fillOpacity: 0.2,
                 }}
               >
                 <Tooltip sticky direction="top" opacity={1}>

--- a/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.css
+++ b/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.css
@@ -4,6 +4,7 @@
   padding: 20px;
   background-color: #ffffff;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), /* ombra principale */ 0 8px 16px rgba(0, 0, 0, 0.1);
+  z-index: 9999;
 }
 
 .filter-table h3 {

--- a/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.tsx
+++ b/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.tsx
@@ -3,10 +3,11 @@ import Document from "../../../models/document";
 import "./FilterPopup.css";
 import API from "../../../API/API";
 import { Button, Col, Dropdown, Row } from "react-bootstrap";
-import ClearIcon from "../../../assets/icons/close.svg";
+
 interface FilterProps {
   setFilteredDocuments: Dispatch<SetStateAction<Document[]>>;
   setFilterTableVisible?: Dispatch<SetStateAction<boolean>>;
+  handleResetNodes?: () => void;
 }
 
 const nodeTypes = [
@@ -96,6 +97,9 @@ const FilterTable: FC<FilterProps> = (props) => {
       language: "",
       description: "",
     });
+    if (props.handleResetNodes) {
+      props.handleResetNodes();
+    }
   };
 
   return (

--- a/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.tsx
+++ b/code/client/src/modules/UrbanPlanner/FilterTable/FilterPopup.tsx
@@ -6,6 +6,7 @@ import { Button, Col, Dropdown, Row } from "react-bootstrap";
 import ClearIcon from "../../../assets/icons/close.svg";
 interface FilterProps {
   setFilteredDocuments: Dispatch<SetStateAction<Document[]>>;
+  setFilterTableVisible?: Dispatch<SetStateAction<boolean>>;
 }
 
 const nodeTypes = [
@@ -29,7 +30,6 @@ const FilterTable: FC<FilterProps> = (props) => {
     language: "",
     description: "",
   });
-  console.log(filters);
 
   interface Filters {
     documentType?: string;
@@ -80,6 +80,9 @@ const FilterTable: FC<FilterProps> = (props) => {
     API.getFilteredDocuments(filters).then((docs) => {
       props.setFilteredDocuments(docs);
     });
+    if (props.setFilterTableVisible) {
+      props.setFilterTableVisible(false);
+    }
   };
 
   const handleReset = (e: React.FormEvent) => {

--- a/code/client/src/modules/style.css
+++ b/code/client/src/modules/style.css
@@ -58,8 +58,7 @@ PAGE STYLE
   max-height: calc(100vh - 130px);
   overflow-y: auto;
   overflow-x: hidden;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1),
-    /* ombra principale */ 0 8px 16px rgba(0, 0, 0, 0.1); /* ombra estesa */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1), /* ombra principale */ 0 8px 16px rgba(0, 0, 0, 0.1); /* ombra estesa */
 }
 
 .row-box-custom {
@@ -1230,8 +1229,7 @@ DIAGRAM
 
   background: transparent;
   background-image: linear-gradient(#333 1px, transparent 0px),
-    /* Adjusted from em to px */
-      linear-gradient(90deg, #333 1px, transparent 0px); /* Adjusted from em to px */
+    /* Adjusted from em to px */ linear-gradient(90deg, #333 1px, transparent 0px); /* Adjusted from em to px */
   background-size: 140px 85px; /* Adjusted from em to px */
   z-index: -1;
 }
@@ -1553,4 +1551,41 @@ DOCUMENT DETAILS
 }
 .col-color-wheel {
   width: 50px !important;
+}
+
+.popup-diagram {
+  position: fixed;
+  top: 58%;
+  right: 0%;
+  transform: translate(-50%, -50%);
+  background-color: transparent;
+  border: none;
+  z-index: 1000;
+}
+
+.popup button {
+  margin-top: 10px;
+}
+
+.open-filter-table-button,
+.open-filter-table-button:hover {
+  z-index: 9999 !important;
+  background-color: white;
+  color: #3d52a0;
+  position: fixed;
+  top: 90px;
+  right: 150px;
+  border: none;
+  margin-top: 5px;
+}
+
+.reset-filter-table-button,
+.reset-filter-table-button:hover {
+  z-index: 9999 !important;
+  background-color: white;
+  color: #3d52a0;
+  position: fixed;
+  top: 90px;
+  right: 20px;
+  border: none;
 }

--- a/code/client/src/modules/style.css
+++ b/code/client/src/modules/style.css
@@ -243,7 +243,8 @@ BUTTON STYLE
   font-size: 18px;
 }
 
-.button-map {
+.button-map,
+.button-map:hover {
   font-size: 16px;
   padding: 6px;
   border-radius: 5px;
@@ -251,13 +252,15 @@ BUTTON STYLE
   width: 120px;
 }
 
-.button-map.hide {
+.button-map.hide,
+.button-map.hide:hover {
   color: #1e1e1e;
   background-color: white;
   border: 2px solide #1e1e1e;
 }
 
-.button-map.show {
+.button-map.show,
+.button-map.show:hover {
   background-color: #333;
   color: white;
   border: 2px solid white;

--- a/code/client/src/modules/style.css
+++ b/code/client/src/modules/style.css
@@ -1573,13 +1573,12 @@ DOCUMENT DETAILS
 .open-filter-table-button,
 .open-filter-table-button:hover {
   z-index: 9999 !important;
-  background-color: white;
-  color: #3d52a0;
+  background-color: #3d52a0;
+  color: white;
   position: fixed;
   top: 90px;
   right: 150px;
-  border: none;
-  margin-top: 5px;
+  border: 1px solid white;
 }
 
 .reset-filter-table-button,
@@ -1589,6 +1588,6 @@ DOCUMENT DETAILS
   color: #3d52a0;
   position: fixed;
   top: 90px;
-  right: 20px;
-  border: none;
+  right: 50px;
+  border: 1px solid #3d52a0;
 }


### PR DESCRIPTION
This pull request includes several changes to the `code/client/src` directory, primarily focusing on enhancing the filtering functionality and improving code readability. The most important changes include adding new state variables and props for filtering, updating the `Diagram` and `DiagramWrapper` components, and refactoring the `DraggableMarker` component.

### Enhancements to Filtering Functionality:
* Added new state variables `filterTableVisible` and `filteredDocuments` to `App.tsx` and passed them as props to relevant components (`[[1]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L44-R40)`, `[[2]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6R159-R162)`).
* Updated `NavBar` to include new props and added buttons for filtering and resetting nodes in the diagram view (`[[1]](diffhunk://#diff-c7fe86fb387d6cf89076d13fa33dfdf2e086145853aec1bfbffa88d80a1320baR8-R18)`, `[[2]](diffhunk://#diff-c7fe86fb387d6cf89076d13fa33dfdf2e086145853aec1bfbffa88d80a1320baR36-R46)`, `[[3]](diffhunk://#diff-c7fe86fb387d6cf89076d13fa33dfdf2e086145853aec1bfbffa88d80a1320baR116-R132)`).
* Modified `Diagram` to handle filtering logic and update nodes based on filtered documents and search title (`[[1]](diffhunk://#diff-a8721f3e2150d46ed562f1e65ccb5184db08cf6572dcbb7804de0c9d0110ff22R11-L29)`, `[[2]](diffhunk://#diff-a8721f3e2150d46ed562f1e65ccb5184db08cf6572dcbb7804de0c9d0110ff22R99-R132)`, `[[3]](diffhunk://#diff-a8721f3e2150d46ed562f1e65ccb5184db08cf6572dcbb7804de0c9d0110ff22R150-R158)`).

### Code Readability Improvements:
* Refactored imports in `App.tsx` and `NavBar.tsx` to improve readability (`[[1]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L2-R2)`, `[[2]](diffhunk://#diff-c7fe86fb387d6cf89076d13fa33dfdf2e086145853aec1bfbffa88d80a1320baR8-R18)`).
* Simplified JSX elements by removing unnecessary line breaks and comments in `App.tsx` (`[[1]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L190-R199)`, `[[2]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L216-R231)`, `[[3]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L270-R272)`, `[[4]](diffhunk://#diff-4942af61739edd17e34a9ec4efd961ee5f621095055f2ae3aff510e2212cf7b6L298-R285)`).

### Diagram Component Updates:
* Added new props to `DiagramWrapper` and passed them to `Diagram` to handle filtering (`[[1]](diffhunk://#diff-9c578ab9355cade57a1de2dfb1d853d3fc301a4d09259db675eb752c58935911L16-R26)`, `[[2]](diffhunk://#diff-9c578ab9355cade57a1de2dfb1d853d3fc301a4d09259db675eb752c58935911R83)`, `[[3]](diffhunk://#diff-9c578ab9355cade57a1de2dfb1d853d3fc301a4d09259db675eb752c58935911R128-R133)`).
* Integrated `FilterTable` component within `Diagram` to display a popup for filtering documents (`[[1]](diffhunk://#diff-a8721f3e2150d46ed562f1e65ccb5184db08cf6572dcbb7804de0c9d0110ff22R11-L29)`, `[[2]](diffhunk://#diff-a8721f3e2150d46ed562f1e65ccb5184db08cf6572dcbb7804de0c9d0110ff22R150-R158)`).

### DraggableMarker Refactoring:
* Refactored `DraggableMarker` to improve readability and consistency by simplifying API calls and reducing nested structures (`[[1]](diffhunk://#diff-77004f1da43bd81440ea15fbf3349016e21873938c0116c0cf5cceb039d96a2aL65-R70)`, `[[2]](diffhunk://#diff-77004f1da43bd81440ea15fbf3349016e21873938c0116c0cf5cceb039d96a2aL88-R91)`, `[[3]](diffhunk://#diff-77004f1da43bd81440ea15fbf3349016e21873938c0116c0cf5cceb039d96a2aL137-R128)`, `[[4]](diffhunk://#diff-77004f1da43bd81440ea15fbf3349016e21873938c0116c0cf5cceb039d96a2aL154-R143)`, `[[5]](diffhunk://#diff-77004f1da43bd81440ea15fbf3349016e21873938c0116c0cf5cceb039d96a2aL223-R210)`).

### CSS Updates:
* Added new CSS classes for filter buttons and updated styles for existing buttons in `index.css` (`[[1]](diffhunk://#diff-05c7928afd88c3b9fb28439d54b8bd99a67fdb1f49e068ed5b11fbfdd0d454c3L459-R460)`, `[[2]](diffhunk://#diff-05c7928afd88c3b9fb28439d54b8bd99a67fdb1f49e068ed5b11fbfdd0d454c3L470-R480)`).